### PR TITLE
Kevin Del Castillo Ramirez (JS Challenges)

### DIFF
--- a/JS-Algorithms/challenges.js
+++ b/JS-Algorithms/challenges.js
@@ -1,3 +1,12 @@
+/**
+ * Create an array for the given range, similar to python.
+ * @param {number} start 
+ * @param {number} end 
+ */
+const bigIntRange = (start, end) => {
+  return Array.from({ length: end - start }, (_, i) => BigInt(i + start))
+}
+
 /* *****
 Challenge 1
 
@@ -13,7 +22,14 @@ Invoking "readableTime(3690)" should return "01:01:30" (HH:MM:SS)
 ***** */
 
 const readableTime = (seconds) => {
-  // YOUR CODE HERE...
+  const format = (number) => `0${number}`.slice(-2);
+
+  const hours = Math.floor(seconds / 3600);
+  seconds = seconds % 3600;
+  const minutes = Math.floor(seconds / 60);
+  seconds = seconds % 60;
+
+  return `${format(hours)}:${format(minutes)}:${format(seconds)}`
 };
 
 readableTime(458);
@@ -41,7 +57,13 @@ Invoking "circularArray(2)" should return "["Island", "Japan", "Israel", "German
 const COUNTRY_NAMES = ["Germany", "Norway", "Island", "Japan", "Israel"];
 
 const circularArray = (index) => {
-  // YOUR CODE HERE...
+  if (index < 0) throw "Index cannot be negative";
+  index = index % COUNTRY_NAMES.length;
+
+  const newHead = COUNTRY_NAMES.slice(index);
+  const newTail = COUNTRY_NAMES.slice(0, index);
+
+  return newHead.concat(newTail)
 };
 
 circularArray(2);
@@ -70,7 +92,13 @@ The last 3 digits for the sum of powers from 1 to 10 is "317"
 ***** */
 
 const ownPower = (number, lastDigits) => {
-  // YOUR CODE HERE...
+  const modulus = (10n ** BigInt(lastDigits))
+  // We could use modular exponentiation, fastest and less memory footprint
+  // Ex: fastPow(i, i, modulus) === (i ** i) % modulus
+  const sum = bigIntRange(1, number + 1)
+    .reduce((acc, i) => acc + i ** i, 0n)
+
+  return (sum % modulus).toString()
 };
 
 ownPower(10, 3);
@@ -95,7 +123,16 @@ Since 10! === 3628800 and you sum 3 + 6 + 2 + 8 + 8 + 0 + 0
 ***** */
 
 const digitSum = (n) => {
-  // YOUR CODE HERE...
+  let fact = bigIntRange(1, n + 1)
+    .reduce((acc, x) => acc * x, 1n)
+
+  let res = 0n;
+  while (fact != 0) {
+    res += fact % 10n;
+    fact = fact / 10n;
+  }
+
+  return Number(res);
 };
 
 digitSum(10);
@@ -118,7 +155,20 @@ Because the 12th index in the Fibonacci sequence is 144, and 144 has three digit
 ***** */
 
 const fibIndex = (n) => {
-  // YOUR CODE HERE...
+  let idx = 0;
+  let a = 0;
+  let b = 1;
+  let temp = 0;
+
+  while (true) {
+    if (`${a}`.length == n)
+      return idx;
+
+    temp = a;
+    a = b;
+    b = temp + b;
+    idx += 1;
+  }
 };
 
 fibIndex(3);

--- a/JS-Algorithms/challenges.test.js
+++ b/JS-Algorithms/challenges.test.js
@@ -67,23 +67,23 @@ describe("Own Powers", () => {
   test('The last 7 digits from the sum of powers all the way to 12 returns "7190184"', () => {
     expect(ownPower(12, 7)).toBe("7190184");
   });
-  test('The last 12 digits from the sum of powers all the way to 21 returns "499809480704"', () => {
-    expect(ownPower(21, 12)).toBe("499809480704");
+  test('The last 12 digits from the sum of powers all the way to 21 returns "75684339445"', () => {
+    expect(ownPower(21, 12)).toBe("75684339445");
   });
 });
 
 describe("Sum of Factorial Digits", () => {
-  test("The sum of the factorial digits of 10 returns the numbet 27", () => {
+  test("The sum of the factorial digits of 10 returns the number 27", () => {
     expect(digitSum(10)).toBe(27);
   });
-  test("The sum of the factorial digits of 42 returns the numbet 207", () => {
-    expect(digitSum(42)).toBe(207);
+  test("The sum of the factorial digits of 42 returns the number 189", () => {
+    expect(digitSum(42)).toBe(189);
   });
-  test("The sum of the factorial digits of 71 returns the numbet 409", () => {
-    expect(digitSum(71)).toBe(409);
+  test("The sum of the factorial digits of 71 returns the number 423", () => {
+    expect(digitSum(71)).toBe(423);
   });
-  test("The sum of the factorial digits of 89 returns the numbet 606", () => {
-    expect(digitSum(89)).toBe(606);
+  test("The sum of the factorial digits of 89 returns the number 549", () => {
+    expect(digitSum(89)).toBe(549);
   });
 });
 

--- a/challenge.py
+++ b/challenge.py
@@ -1,0 +1,41 @@
+# Copyright (C) 2021 Kevin Del Castillo Ramírez
+# 
+# This file is part of Module1.
+# 
+# Module1 is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# 
+# Module1 is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with Module1.  If not, see <http://www.gnu.org/licenses/>.
+
+import math
+
+def own_power(n, digits):
+    powers = sum([i ** i for i in range(1, n + 1)])
+    return f"{powers % (10 ** digits)}"
+
+print(f"own_power(10, 3) = {own_power(10, 3)}")
+print(f"own_power(12, 7) = {own_power(12, 7)}")
+print(f"own_power(21, 12) = {own_power(21, 12)}")
+
+
+def digit_sum(n):
+    fact = math.factorial(n)
+    res = 0
+    while fact != 0:
+        res += fact % 10
+        fact = fact // 10
+    return res 
+
+print()
+print(f"digit_sum(10) = {digit_sum(10)}")
+print(f"digit_sum(42) = {digit_sum(42)}")
+print(f"digit_sum(71) = {digit_sum(71)}")
+print(f"digit_sum(89) = {digit_sum(89)}")


### PR DESCRIPTION
I noticed that there are some incorrect unit tests for `ownPower` and `digitSum`. For the former the last test is failing (i.e. `ownPower(21, 12)`) because `21 ** 21` is larger than [`Number.MAX_SAFE_INTEGER`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER) this already creates an overflow, if you don't use a `BigInt` from the beginning final sum is obviously going to be bigger than `Number.MAX_SAFE_INTEGER`, and for the latter something similar was happening, take for example the factorial of 42, this number is also going to be greater than `Number.MAX_SAFE_INTEGER` using `number` here is _incorrect_ because it's going to produce an overflow.

Python interpreter:
```py
>>> MAX_SAFE_INTEGER = 2 ** 53 - 1
>>> 21 ** 21 > MAX_SAFE_INTEGER
True
>>> import math
>>> math.factorial(42) > MAX_SAFE_INTEGER
True
```

To prove these points I included a Python3 script (`challenge.py`) with implementations to those two functions, but with the difference that Python3 supports **arbitrarily large** numbers out of the box, if you run this script you'll see the correct values. 